### PR TITLE
4.1.0, add a new option called 'changedFile'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ builder(options)
   - pkg: mixed package json format of project
   - targetVersion: target version to build
   - cwd: current working directory
+  - changedFile: the file has been changed. If it has no relations with the parsing file, an `ENOTNEEDBUILD` error will be thrown.
   - allowNotInstalled
   
 - file `Path` the parsing file

--- a/index.js
+++ b/index.js
@@ -172,6 +172,14 @@ Parser.prototype._getDeps = function(filepath, callback) {
     loaders: this.loaders
   }, function(err, deps){
     if(err){return callback(err);}
+
+    var changedFile = self.opt.changedFile;
+    if (changedFile && !(deps && (changedFile in deps))) {
+      err = new Error("Not need build the file");
+      err.code = 'ENOTNEEDBUILD';
+      return callback(err);
+    }
+
     callback(null, deps);
   })
   .on('warn', function (message) {

--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ function Parser (opt) {
   this.asyncDependencies = this.pkg.asyncDependencies || {};
   this.as = this.pkg.as || {};
   this.loaders = opt.loaders;
-  this.loader_version = opt.loader_version;
 
   var asyncDependencies = this.asyncDependencies;
   var as = this.as;
@@ -161,7 +160,7 @@ Parser.prototype._generateCode = function(codes, callback) {
 
 Parser.prototype._getDeps = function(filepath, callback) {
   var self = this;
-  var walker = require('cortex-commonjs-walker');
+  var walker = require('commonjs-walker');
   var pkg = this.pkg;
   walker(filepath, {
     allowCyclic: true,
@@ -170,14 +169,10 @@ Parser.prototype._getDeps = function(filepath, callback) {
     extensions: ['.js', '.json'],
     cwd: self.cwd,
     'as': pkg['as'] || {},
-    loaders: this.loaders,
-    loader_version: this.loader_version
+    loaders: this.loaders
   }, function(err, deps){
     if(err){return callback(err);}
     callback(null, deps);
-  })
-  .on('dependency', function(mod, parent){
-    self.emit('dependency', mod, parent);
   })
   .on('warn', function (message) {
     self.emit('warn', message);
@@ -218,7 +213,7 @@ Parser.prototype._wrapping = function(id, mod) {
   var result = _.template(template)({
     id: self._toLocals(id),
     deps: this._toLocals(resolvedDeps),
-    code: this._dealCode(id, code),
+    code: this.dealCode(id, code),
     module_options: module_options
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-neuron-builder",
-  "version": "4.0.6",
+  "version": "4.0.8",
   "description": "Wrap commonjs module/1.0 javascript files for [cortex](http://github.com/kaelzhang/cortex)",
   "main": "index.js",
   "scripts": {
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "async": "^0.9.0",
-    "cortex-commonjs-walker": "^5.0.0",
+    "commonjs-walker": "^5.0.2",
     "underscore": "^1.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-neuron-builder",
-  "version": "4.0.8",
+  "version": "4.1.0",
   "description": "Wrap commonjs module/1.0 javascript files for [cortex](http://github.com/kaelzhang/cortex)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
1. Skip to `4.0.8` based on `npm`. Well, it's better to ask @supersheep to merge those commits back.
2. Add a new option `changedFile`, so that the builder will reject unnecessary builds.

> changedFile: the file has been changed. If it has no relations with the parsing file, an `ENOTNEEDBUILD` error will be thrown.
